### PR TITLE
Add fzf border and TSTagDelimiter

### DIFF
--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -386,6 +386,7 @@ highlight! link TSRepeat Red
 highlight! link TSLabel Orange
 highlight! link TSOperator Orange
 highlight! link TSKeyword Red
+highlight! link TSTagDelimiter Green
 highlight! link TSException Red
 highlight! link TSType Aqua
 highlight! link TSTypeBuiltin BlueItalic
@@ -543,6 +544,7 @@ let g:fzf_colors = {
       \ 'bg+':     ['bg', 'CursorLine', 'CursorColumn'],
       \ 'hl+':     ['fg', 'Aqua'],
       \ 'info':    ['fg', 'Aqua'],
+      \ 'border':  ['fg', 'Grey'],
       \ 'prompt':  ['fg', 'Orange'],
       \ 'pointer': ['fg', 'Blue'],
       \ 'marker':  ['fg', 'Yellow'],


### PR DESCRIPTION
Another tiny addition. Fzf was missing a highlight for its border. This adds that as well as `TSTagDelimiter`.

Before:
<img width="1884" alt="Screenshot 2020-11-25 at 19 44 40" src="https://user-images.githubusercontent.com/2834949/100269795-651d2080-2f57-11eb-85d6-e3dda8b7abf6.png">


After:
<img width="1884" alt="Screenshot 2020-11-25 at 22 02 17" src="https://user-images.githubusercontent.com/2834949/100281295-f09fad00-2f69-11eb-84b4-9a5c633a58e7.png">