### PR TITLE
LspDiagnosticsVirtualText fix for neovim-lsp

### DIFF
--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -159,10 +159,10 @@ if has('nvim')
   highlight! link LspDiagnosticsDefaultWarning WarningText
   highlight! link LspDiagnosticsDefaultInformation InfoText
   highlight! link LspDiagnosticsDefaultHint HintText
-  highlight! link LspDiagnosticsVirtualTextError Grey
-  highlight! link LspDiagnosticsVirtualTextWarning Grey
-  highlight! link LspDiagnosticsVirtualTextInformation Grey
-  highlight! link LspDiagnosticsVirtualTextHint Grey
+  highlight! link LspDiagnosticsVirtualTextError Red
+  highlight! link LspDiagnosticsVirtualTextWarning Yellow
+  highlight! link LspDiagnosticsVirtualTextInformation Orange
+  highlight! link LspDiagnosticsVirtualTextHint Blue
   highlight! link LspDiagnosticsUnderlineError ErrorText
   highlight! link LspDiagnosticsUnderlineWarning WarningText
   highlight! link LspDiagnosticsUnderlineInformation InfoText


### PR DESCRIPTION
Due to LspDiagnosticsVirtualText fields values set as "Grey" all neovim-lsp messages were also grey. They have been changed to more appropriate colors.