### PR TITLE
fix(tree-sitter): make function and method bold

### DIFF
--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -418,13 +418,13 @@ highlight! link TSField Green
 highlight! link TSFloat Purple
 highlight! link TSFuncBuiltin Green
 highlight! link TSFuncMacro Green
-highlight! link TSFunction Green
+highlight! link TSFunction GreenBold
 highlight! link TSInclude Red
 highlight! link TSKeyword Red
 highlight! link TSKeywordFunction Red
 highlight! link TSKeywordOperator Orange
 highlight! link TSLabel Orange
-highlight! link TSMethod Green
+highlight! link TSMethod GreenBold
 highlight! link TSNamespace YellowItalic
 highlight! link TSNone Fg
 highlight! link TSNumber Purple

--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -416,8 +416,8 @@ highlight! link TSError ErrorText
 highlight! link TSException Red
 highlight! link TSField Green
 highlight! link TSFloat Purple
-highlight! link TSFuncBuiltin Green
-highlight! link TSFuncMacro Green
+highlight! link TSFuncBuiltin GreenBold
+highlight! link TSFuncMacro GreenBold
 highlight! link TSFunction GreenBold
 highlight! link TSInclude Red
 highlight! link TSKeyword Red


### PR DESCRIPTION
I don't exactly know what `TSFuncMacro` or `TSFuncBuiltin` are, but should they be bold as well?

Also, should I update the code to do `bold`/`italic` highlights only if `enable_bold`/`enable_italic` is true, just like everywhere else?