### PR TITLE
feat(configuration): add option spell_foreground_unchanged

### DIFF
--- a/autoload/gruvbox_material.vim
+++ b/autoload/gruvbox_material.vim
@@ -20,6 +20,7 @@ function! gruvbox_material#get_configuration() "{{{
         \ 'disable_italic_comment': get(g:, 'gruvbox_material_disable_italic_comment', 0),
         \ 'enable_bold': get(g:, 'gruvbox_material_enable_bold', 0),
         \ 'enable_italic': get(g:, 'gruvbox_material_enable_italic', 0),
+        \ 'spell_foreground_unchanged': get(g:, 'gruvbox_material_spell_foreground_unchanged', 0),
         \ 'cursor': get(g:, 'gruvbox_material_cursor', 'auto'),
         \ 'visual': get(g:, 'gruvbox_material_visual', 'grey background'),
         \ 'menu_selection_background': get(g:, 'gruvbox_material_menu_selection_background', 'grey'),

--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -109,15 +109,22 @@ elseif s:configuration.menu_selection_background ==# 'red'
   call gruvbox_material#highlight('PmenuSel', s:palette.bg3, s:palette.bg_red)
 else
   call gruvbox_material#highlight('PmenuSel', s:palette.bg3, s:palette[s:configuration.menu_selection_background])
-end
+endif
 highlight! link WildMenu PmenuSel
 call gruvbox_material#highlight('PmenuThumb', s:palette.none, s:palette.grey0)
 call gruvbox_material#highlight('NormalFloat', s:palette.fg1, s:palette.bg3)
 call gruvbox_material#highlight('Question', s:palette.yellow, s:palette.none)
-call gruvbox_material#highlight('SpellBad', s:palette.red, s:palette.none, 'undercurl', s:palette.red)
-call gruvbox_material#highlight('SpellCap', s:palette.blue, s:palette.none, 'undercurl', s:palette.blue)
-call gruvbox_material#highlight('SpellLocal', s:palette.aqua, s:palette.none, 'undercurl', s:palette.aqua)
-call gruvbox_material#highlight('SpellRare', s:palette.purple, s:palette.none, 'undercurl', s:palette.purple)
+if s:configuration.spell_foreground_unchanged
+  call gruvbox_material#highlight('SpellBad', s:palette.none, s:palette.none, 'undercurl', s:palette.red)
+  call gruvbox_material#highlight('SpellCap', s:palette.none, s:palette.none, 'undercurl', s:palette.blue)
+  call gruvbox_material#highlight('SpellLocal', s:palette.none, s:palette.none, 'undercurl', s:palette.aqua)
+  call gruvbox_material#highlight('SpellRare', s:palette.none, s:palette.none, 'undercurl', s:palette.purple)
+else
+  call gruvbox_material#highlight('SpellBad', s:palette.red, s:palette.none, 'undercurl', s:palette.red)
+  call gruvbox_material#highlight('SpellCap', s:palette.blue, s:palette.none, 'undercurl', s:palette.blue)
+  call gruvbox_material#highlight('SpellLocal', s:palette.aqua, s:palette.none, 'undercurl', s:palette.aqua)
+  call gruvbox_material#highlight('SpellRare', s:palette.purple, s:palette.none, 'undercurl', s:palette.purple)
+endif
 if s:configuration.statusline_style ==# 'original'
   call gruvbox_material#highlight('StatusLine', s:palette.grey2, s:palette.bg_statusline2)
   call gruvbox_material#highlight('StatusLineTerm', s:palette.grey2, s:palette.bg_statusline2)

--- a/doc/gruvbox-material.txt
+++ b/doc/gruvbox-material.txt
@@ -229,6 +229,17 @@ Note: This option is designed to use with fonts that support cursive italics.
 See |gruvbox-material-faq| for more information.
 
 ------------------------------------------------------------------------------
+                                 *g:gruvbox_material_spell_foreground_unchanged*
+g:gruvbox_material_spell_foreground_unchanged~
+
+This color scheme may change the foreground colors of words not recognized by
+the spell checker. To leave them unchanged, set this option to `1`.
+
+E.g.
+>
+    let g:gruvbox_material_spell_foreground_unchanged = 1
+<
+------------------------------------------------------------------------------
                                                      *g:gruvbox_material_cursor*
 g:gruvbox_material_cursor~
 


### PR DESCRIPTION
In plain text, this color scheme changes the foreground colors of words not recognized by the spell checker, which can make the text look ugly. Setting `g:gruvbox_material_spell_foreground_unchanged` to `1` leaves them unchanged. Undercurl is still added.