### PR TITLE
perf(tmux): Remove tmux check that slows down

### DIFF
--- a/autoload/gruvbox_material.vim
+++ b/autoload/gruvbox_material.vim
@@ -6,12 +6,6 @@
 " License: MIT License
 " =============================================================================
 
-" g:gruvbox_material#tmux: is in tmux < 2.9 or not {{{
-let g:gruvbox_material#tmux = executable('tmux') && $TMUX !=# '' ?
-                  \ (str2float(system("tmux -V | grep -oE '[0-9]+\.[0-9]*'")) < 2.9 ?
-                    \ 1 :
-                    \ 0) :
-                  \ 0 "}}}
 function! gruvbox_material#get_configuration() "{{{
   return {
         \ 'background': get(g:, 'gruvbox_material_background', 'medium'),
@@ -288,9 +282,7 @@ function! gruvbox_material#highlight(group, fg, bg, ...) "{{{
         \ 'ctermbg=' . a:bg[1]
         \ 'gui=' . (a:0 >= 1 ?
           \ (a:1 ==# 'undercurl' ?
-            \ (g:gruvbox_material#tmux ?
-              \ 'underline' :
-              \ 'undercurl') :
+            \ 'undercurl' :
             \ a:1) :
           \ 'NONE')
         \ 'cterm=' . (a:0 >= 1 ?


### PR DESCRIPTION
Just forked the theme and modifying it realized that without that tmux
check the startuptime is reduced x10