### PR TITLE
Check for disabled_terminal_colors before accessing it

### DIFF
--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -422,7 +422,10 @@ endif
 " }}}
 " }}}
 " Terminal: {{{
-if ((has('termguicolors') && &termguicolors) || has('gui_running')) && !s:configuration.disable_terminal_colors
+let s:has_gui_colors = (has('termguicolors') && &termguicolors) || has('gui_running')
+let s:enable_terminal_colors = !has_key(s:configuration, 'disable_terminal_colors') || !s:configuration.disable_terminal_colors
+
+if s:has_gui_colors && s:enable_terminal_colors
   " Definition
   let s:terminal = {
         \ 'black':         &background ==# 'dark' ? s:palette.bg5 : s:palette.fg0,


### PR DESCRIPTION
I just upgraded to Neovim 0.7 and started seeing an error when accessing this setting. I'm guessing it might be a symptom of a separate issue, though, so let me know if you want me to dig in more before settling on this.

-------

<img width="1089" alt="error" src="https://user-images.githubusercontent.com/288160/164787301-c3d9f96a-590f-482f-8b75-983406fbe3d4.png">


