### PR TITLE
feat(ts): add `@type.definition` and `@type.qualifier`

### DIFF
--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -547,6 +547,8 @@ highlight! link TSStrike Grey
 highlight! link TSMath Blue
 highlight! link TSType Yellow
 highlight! link TSTypeBuiltin YellowItalic
+highlight! link TSTypeDefinition Red
+highlight! link TSTypeQualifier Red
 highlight! link TSURI markdownUrl
 highlight! link TSVariable Fg
 highlight! link TSVariableBuiltin BlueItalic
@@ -596,6 +598,8 @@ if has('nvim-0.8.0')
   highlight! link @math TSMath
   highlight! link @type TSType
   highlight! link @type.builtin TSTypeBuiltin
+  highlight! link @type.definition TSTypeDefinition
+  highlight! link @type.qualifier TSTypeQualifier
   highlight! link @uri TSURI
   highlight! link @variable TSVariable
   highlight! link @variable.builtin TSVariableBuiltin

--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -547,8 +547,8 @@ highlight! link TSStrike Grey
 highlight! link TSMath Blue
 highlight! link TSType Yellow
 highlight! link TSTypeBuiltin YellowItalic
-highlight! link TSTypeDefinition Red
-highlight! link TSTypeQualifier Red
+highlight! link TSTypeDefinition Yellow
+highlight! link TSTypeQualifier Yellow
 highlight! link TSURI markdownUrl
 highlight! link TSVariable Fg
 highlight! link TSVariableBuiltin BlueItalic


### PR DESCRIPTION
This PR adds `@type.definition` and `@type.qualifier`, that are used for Rust (at least, from https://github.com/nvim-treesitter/nvim-treesitter/commit/00b42ac6d4c852d34619eaf2ea822266588d75e3).
