### PR TITLE
Add YcmErrorText and YcmWarningText highlight

### DIFF
--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -768,7 +768,9 @@ highlight! link LspSemanticOperator TSOperator
 " }}}
 " ycm-core/YouCompleteMe {{{
 highlight! link YcmErrorSign RedSign
+highlight! link YcmErrorText RedSign
 highlight! link YcmWarningSign YellowSign
+highlight! link YcmWarningText YellowSign
 highlight! link YcmErrorLine ErrorLine
 highlight! link YcmWarningLine WarningLine
 highlight! link YcmErrorSection ErrorText

--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -768,14 +768,14 @@ highlight! link LspSemanticOperator TSOperator
 " }}}
 " ycm-core/YouCompleteMe {{{
 highlight! link YcmErrorSign RedSign
-highlight! link YcmErrorText RedSign
 highlight! link YcmWarningSign YellowSign
-highlight! link YcmWarningText YellowSign
 highlight! link YcmErrorLine ErrorLine
 highlight! link YcmWarningLine WarningLine
 highlight! link YcmErrorSection ErrorText
 highlight! link YcmWarningSection WarningText
 highlight! link YcmInlayHint LineNr
+highlight! link YcmErrorText VirtualTextError
+highlight! link YcmWarningText VirtualTextWarning
 if !has('nvim') && has('textprop') && !exists('g:YCM_HIGHLIGHT_GROUP')
   let g:YCM_HIGHLIGHT_GROUP = {
         \ 'typeParameter': 'TSType',

--- a/doc/gruvbox-material.txt
+++ b/doc/gruvbox-material.txt
@@ -436,6 +436,7 @@ Currently, the following plugins are supported:
 - https://github.com/prabirshrestha/vim-lsp
 - https://github.com/dense-analysis/ale
 - https://github.com/neomake/neomake
+- https://github.com/ycm-core/YouCompleteMe
 
 ------------------------------------------------------------------------------
                                                *g:gruvbox_material_current_word*


### PR DESCRIPTION
Adding missing hl for [YouCompleteMe](https://github.com/ycm-core/YouCompleteMe) virtual text.

This makes virtual text displayed next to warning and errors colored yellow or red when [virtual text is enabled](https://github.com/ycm-core/YouCompleteMe#the-gycm_echo_current_diagnostic-option).

![2022-12-16_19:53:27](https://user-images.githubusercontent.com/76585/208169015-9c537b3d-6652-4026-828c-c985cc4f4f7a.png)
