### PR TITLE
Add palette previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,41 @@ There are 3 palettes available in this color scheme:
 
 </details>
 
+Below are the full palettes for your own artistic endeavors:
+
+<details>
+  <summary><code>material</code>: Carefully designed to have a soft contrast</summary>
+
+|        |                                                             𝐃𝐚𝐫𝐤                                                              |                                                             𝐋𝐢𝐠𝐡𝐭                                                              |
+| :----: | :---------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------: |
+|  𝐇𝐚𝐫𝐝  |  ![material-hard-dark](https://user-images.githubusercontent.com/58662350/213884009-87533cf3-e3c5-4d46-85f7-f6993b6dd887.png)  |  ![material-hard-light](https://user-images.githubusercontent.com/58662350/213884015-bd5a31bd-ccb5-4841-8caa-70cdb10a6b0e.png)  |
+| 𝐌𝐞𝐝𝐢𝐮𝐦 | ![material-medium-dark](https://user-images.githubusercontent.com/58662350/213884019-cbcd5f00-5bef-4a37-9139-0570770330b6.png) | ![material-medium-light](https://user-images.githubusercontent.com/58662350/213884028-26b692fc-4a2d-40f7-8ecb-ae28fa69c6b0.png) |
+|  𝐒𝐨𝐟𝐭  |  ![material-soft-dark](https://user-images.githubusercontent.com/58662350/213884037-97bb9a1b-cc5a-46c1-8d44-877cd85b1cdc.png)  |  ![material-soft-light](https://user-images.githubusercontent.com/58662350/213884039-4eac92cc-c23a-4add-8d45-6838daf9d48b.png)  |
+
+</details>
+
+<details>
+  <summary><code>mix</code>: Color palette obtained by calculating the mean of the other two</summary>
+
+|        |                                                           𝐃𝐚𝐫𝐤                                                           |                                                           𝐋𝐢𝐠𝐡𝐭                                                           |
+| :----: | :----------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------: |
+|  𝐇𝐚𝐫𝐝  |  ![mix-hard-dark](https://user-images.githubusercontent.com/58662350/213884044-fdd95ba6-d75c-4983-8297-f5b39d794027.png)  |  ![mix-hard-light](https://user-images.githubusercontent.com/58662350/213884055-a5615ee6-c14e-422b-8971-112f55c4b745.png)  |
+| 𝐌𝐞𝐝𝐢𝐮𝐦 | ![mix-medium-dark](https://user-images.githubusercontent.com/58662350/213884062-3d9574ea-9f92-4d4e-b53a-46726192fffa.png) | ![mix-medium-light](https://user-images.githubusercontent.com/58662350/213884069-edbbb8a6-1150-46af-8e68-3ab0a0066b96.png) |
+|  𝐒𝐨𝐟𝐭  |  ![mix-soft-dark](https://user-images.githubusercontent.com/58662350/213884074-4c351ba6-deb5-4bda-abfc-2d78fe4fedd4.png)  |  ![mix-soft-light](https://user-images.githubusercontent.com/58662350/213884077-182b1cda-dfab-4a07-b76a-bc70490d7d54.png)  |
+
+</details>
+
+<details>
+  <summary><code>original</code>: The color palette used in the original gruvbox</summary>
+
+|        |                                                             𝐃𝐚𝐫𝐤                                                              |                                                             𝐋𝐢𝐠𝐡𝐭                                                              |
+| :----: | :---------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------: |
+|  𝐇𝐚𝐫𝐝  |  ![original-hard-dark](https://user-images.githubusercontent.com/58662350/213884080-8f3be305-8ff1-48d2-9bc8-c6db4ed9c143.png)  |  ![original-hard-light](https://user-images.githubusercontent.com/58662350/213884083-becbfe22-e063-4dcd-8ee0-14fc5b52c77b.png)  |
+| 𝐌𝐞𝐝𝐢𝐮𝐦 | ![original-medium-dark](https://user-images.githubusercontent.com/58662350/213884089-4cea3374-b918-4bd1-8ca5-ac87a9bb9d83.png) | ![original-medium-light](https://user-images.githubusercontent.com/58662350/213884092-b4336e83-8556-4f04-a0e5-8e18ab57800f.png) |
+|  𝐒𝐨𝐟𝐭  |  ![original-soft-dark](https://user-images.githubusercontent.com/58662350/213884099-88d47fa6-ea20-49ad-b706-072e928b3e0a.png)  |  ![original-soft-light](https://user-images.githubusercontent.com/58662350/213884102-ab77fd5a-455f-4195-a7bb-61182d2989fc.png)  |
+
+</details>
+
 This color scheme uses the `material` palette by default, you can use a global variable to switch to another palette.
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Gruvbox Material is a modified version of [Gruvbox](https://github.com/morhetz/gruvbox), the contrast is adjusted to be softer in order to protect developers' eyes.
 
-There are 3 palettes available in this color scheme:
+There are 3 palettes available in this color scheme:  
+Full color previews are included for your convenience
 
 👏 𝑵𝒐𝒕𝒆: 𝒄𝒍𝒊𝒄𝒌 𝒐𝒏 𝒕𝒉𝒆 𝒇𝒐𝒍𝒍𝒐𝒘𝒊𝒏𝒈 𝒍𝒊𝒏𝒆𝒔 𝒕𝒐 𝒑𝒓𝒆𝒗𝒊𝒆𝒘
 
@@ -11,9 +12,9 @@ There are 3 palettes available in this color scheme:
 
 |        |                                                             𝐃𝐚𝐫𝐤                                                              |                                                             𝐋𝐢𝐠𝐡𝐭                                                              |
 | :----: | :---------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------: |
-|  𝐇𝐚𝐫𝐝  |  ![material-hard-dark](https://user-images.githubusercontent.com/37491630/75227134-891fbb80-57a5-11ea-878e-b8b2972cfd6e.png)  |  ![material-hard-light](https://user-images.githubusercontent.com/37491630/75227137-8a50e880-57a5-11ea-90dc-b2646d8b0b55.png)  |
-| 𝐌𝐞𝐝𝐢𝐮𝐦 | ![material-medium-dark](https://user-images.githubusercontent.com/37491630/75227139-8cb34280-57a5-11ea-86d6-3d3f6a2475eb.png) | ![material-medium-light](https://user-images.githubusercontent.com/37491630/75227141-8de46f80-57a5-11ea-820a-9394ab9d09aa.png) |
-|  𝐒𝐨𝐟𝐭  |  ![material-soft-dark](https://user-images.githubusercontent.com/37491630/75227149-9046c980-57a5-11ea-8633-bf4f31e533d0.png)  |  ![material-soft-light](https://user-images.githubusercontent.com/37491630/75227157-92108d00-57a5-11ea-8b13-b2130bff60d8.png)  |
+|  𝐇𝐚𝐫𝐝  |  ![material-hard-dark](https://user-images.githubusercontent.com/37491630/75227134-891fbb80-57a5-11ea-878e-b8b2972cfd6e.png) ![material-hard-dark](https://user-images.githubusercontent.com/58662350/213884009-87533cf3-e3c5-4d46-85f7-f6993b6dd887.png) |  ![material-hard-light](https://user-images.githubusercontent.com/37491630/75227137-8a50e880-57a5-11ea-90dc-b2646d8b0b55.png) ![material-hard-light](https://user-images.githubusercontent.com/58662350/213884015-bd5a31bd-ccb5-4841-8caa-70cdb10a6b0e.png)  |
+| 𝐌𝐞𝐝𝐢𝐮𝐦 | ![material-medium-dark](https://user-images.githubusercontent.com/37491630/75227139-8cb34280-57a5-11ea-86d6-3d3f6a2475eb.png) ![material-medium-dark](https://user-images.githubusercontent.com/58662350/213884019-cbcd5f00-5bef-4a37-9139-0570770330b6.png) | ![material-medium-light](https://user-images.githubusercontent.com/37491630/75227141-8de46f80-57a5-11ea-820a-9394ab9d09aa.png) ![material-medium-light](https://user-images.githubusercontent.com/58662350/213884028-26b692fc-4a2d-40f7-8ecb-ae28fa69c6b0.png) |
+|  𝐒𝐨𝐟𝐭  |  ![material-soft-dark](https://user-images.githubusercontent.com/37491630/75227149-9046c980-57a5-11ea-8633-bf4f31e533d0.png) ![material-soft-dark](https://user-images.githubusercontent.com/58662350/213884037-97bb9a1b-cc5a-46c1-8d44-877cd85b1cdc.png)  |  ![material-soft-light](https://user-images.githubusercontent.com/37491630/75227157-92108d00-57a5-11ea-8b13-b2130bff60d8.png) ![material-soft-light](https://user-images.githubusercontent.com/58662350/213884039-4eac92cc-c23a-4add-8d45-6838daf9d48b.png)  |
 
 </details>
 
@@ -22,9 +23,9 @@ There are 3 palettes available in this color scheme:
 
 |        |                                                           𝐃𝐚𝐫𝐤                                                           |                                                           𝐋𝐢𝐠𝐡𝐭                                                           |
 | :----: | :----------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------: |
-|  𝐇𝐚𝐫𝐝  |  ![mix-hard-dark](https://user-images.githubusercontent.com/37491630/76383368-826f7780-6353-11ea-8094-b593eb5f1e10.png)  |  ![mix-hard-light](https://user-images.githubusercontent.com/37491630/76383372-88655880-6353-11ea-9441-78d159600faf.png)  |
-| 𝐌𝐞𝐝𝐢𝐮𝐦 | ![mix-medium-dark](https://user-images.githubusercontent.com/37491630/76383370-84393b00-6353-11ea-88de-804a781d3142.png) | ![mix-medium-light](https://user-images.githubusercontent.com/37491630/76383375-8ac7b280-6353-11ea-94a8-62e3845203bc.png) |
-|  𝐒𝐨𝐟𝐭  |  ![mix-soft-dark](https://user-images.githubusercontent.com/37491630/76383371-869b9500-6353-11ea-923d-9011bbe6bcad.png)  |  ![mix-soft-light](https://user-images.githubusercontent.com/37491630/76383380-8c917600-6353-11ea-8530-a67932a6a2ec.png)  |
+|  𝐇𝐚𝐫𝐝  |  ![mix-hard-dark](https://user-images.githubusercontent.com/37491630/76383368-826f7780-6353-11ea-8094-b593eb5f1e10.png) ![mix-hard-dark](https://user-images.githubusercontent.com/58662350/213884044-fdd95ba6-d75c-4983-8297-f5b39d794027.png)  |  ![mix-hard-light](https://user-images.githubusercontent.com/37491630/76383372-88655880-6353-11ea-9441-78d159600faf.png) ![mix-hard-light](https://user-images.githubusercontent.com/58662350/213884055-a5615ee6-c14e-422b-8971-112f55c4b745.png)  |
+| 𝐌𝐞𝐝𝐢𝐮𝐦 | ![mix-medium-dark](https://user-images.githubusercontent.com/37491630/76383370-84393b00-6353-11ea-88de-804a781d3142.png) ![mix-medium-dark](https://user-images.githubusercontent.com/58662350/213884062-3d9574ea-9f92-4d4e-b53a-46726192fffa.png) | ![mix-medium-light](https://user-images.githubusercontent.com/37491630/76383375-8ac7b280-6353-11ea-94a8-62e3845203bc.png) ![mix-medium-light](https://user-images.githubusercontent.com/58662350/213884069-edbbb8a6-1150-46af-8e68-3ab0a0066b96.png) |
+|  𝐒𝐨𝐟𝐭  |  ![mix-soft-dark](https://user-images.githubusercontent.com/37491630/76383371-869b9500-6353-11ea-923d-9011bbe6bcad.png) ![mix-soft-dark](https://user-images.githubusercontent.com/58662350/213884074-4c351ba6-deb5-4bda-abfc-2d78fe4fedd4.png)  |  ![mix-soft-light](https://user-images.githubusercontent.com/37491630/76383380-8c917600-6353-11ea-8530-a67932a6a2ec.png) ![mix-soft-light](https://user-images.githubusercontent.com/58662350/213884077-182b1cda-dfab-4a07-b76a-bc70490d7d54.png)  |
 
 </details>
 
@@ -33,44 +34,9 @@ There are 3 palettes available in this color scheme:
 
 |        |                                                             𝐃𝐚𝐫𝐤                                                              |                                                             𝐋𝐢𝐠𝐡𝐭                                                              |
 | :----: | :---------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------: |
-|  𝐇𝐚𝐫𝐝  |  ![original-hard-dark](https://user-images.githubusercontent.com/37491630/76383382-8e5b3980-6353-11ea-9398-08d31b1ed32d.png)  |  ![original-hard-light](https://user-images.githubusercontent.com/37491630/76383389-931fed80-6353-11ea-905f-47b35c0cac39.png)  |
-| 𝐌𝐞𝐝𝐢𝐮𝐦 | ![original-medium-dark](https://user-images.githubusercontent.com/37491630/76383385-9024fd00-6353-11ea-99c1-7bba4f796115.png) | ![original-medium-light](https://user-images.githubusercontent.com/37491630/76383393-94511a80-6353-11ea-84ea-551b44f0d5bd.png) |
-|  𝐒𝐨𝐟𝐭  |  ![original-soft-dark](https://user-images.githubusercontent.com/37491630/76383387-91562a00-6353-11ea-90a0-daac8653dfd0.png)  |  ![original-soft-light](https://user-images.githubusercontent.com/37491630/76383396-95824780-6353-11ea-9b36-302b88fef429.png)  |
-
-</details>
-
-Below are the full palettes for your own artistic endeavors:
-
-<details>
-  <summary><code>material</code>: Carefully designed to have a soft contrast</summary>
-
-|        |                                                             𝐃𝐚𝐫𝐤                                                              |                                                             𝐋𝐢𝐠𝐡𝐭                                                              |
-| :----: | :---------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------: |
-|  𝐇𝐚𝐫𝐝  |  ![material-hard-dark](https://user-images.githubusercontent.com/58662350/213884009-87533cf3-e3c5-4d46-85f7-f6993b6dd887.png)  |  ![material-hard-light](https://user-images.githubusercontent.com/58662350/213884015-bd5a31bd-ccb5-4841-8caa-70cdb10a6b0e.png)  |
-| 𝐌𝐞𝐝𝐢𝐮𝐦 | ![material-medium-dark](https://user-images.githubusercontent.com/58662350/213884019-cbcd5f00-5bef-4a37-9139-0570770330b6.png) | ![material-medium-light](https://user-images.githubusercontent.com/58662350/213884028-26b692fc-4a2d-40f7-8ecb-ae28fa69c6b0.png) |
-|  𝐒𝐨𝐟𝐭  |  ![material-soft-dark](https://user-images.githubusercontent.com/58662350/213884037-97bb9a1b-cc5a-46c1-8d44-877cd85b1cdc.png)  |  ![material-soft-light](https://user-images.githubusercontent.com/58662350/213884039-4eac92cc-c23a-4add-8d45-6838daf9d48b.png)  |
-
-</details>
-
-<details>
-  <summary><code>mix</code>: Color palette obtained by calculating the mean of the other two</summary>
-
-|        |                                                           𝐃𝐚𝐫𝐤                                                           |                                                           𝐋𝐢𝐠𝐡𝐭                                                           |
-| :----: | :----------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------: |
-|  𝐇𝐚𝐫𝐝  |  ![mix-hard-dark](https://user-images.githubusercontent.com/58662350/213884044-fdd95ba6-d75c-4983-8297-f5b39d794027.png)  |  ![mix-hard-light](https://user-images.githubusercontent.com/58662350/213884055-a5615ee6-c14e-422b-8971-112f55c4b745.png)  |
-| 𝐌𝐞𝐝𝐢𝐮𝐦 | ![mix-medium-dark](https://user-images.githubusercontent.com/58662350/213884062-3d9574ea-9f92-4d4e-b53a-46726192fffa.png) | ![mix-medium-light](https://user-images.githubusercontent.com/58662350/213884069-edbbb8a6-1150-46af-8e68-3ab0a0066b96.png) |
-|  𝐒𝐨𝐟𝐭  |  ![mix-soft-dark](https://user-images.githubusercontent.com/58662350/213884074-4c351ba6-deb5-4bda-abfc-2d78fe4fedd4.png)  |  ![mix-soft-light](https://user-images.githubusercontent.com/58662350/213884077-182b1cda-dfab-4a07-b76a-bc70490d7d54.png)  |
-
-</details>
-
-<details>
-  <summary><code>original</code>: The color palette used in the original gruvbox</summary>
-
-|        |                                                             𝐃𝐚𝐫𝐤                                                              |                                                             𝐋𝐢𝐠𝐡𝐭                                                              |
-| :----: | :---------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------: |
-|  𝐇𝐚𝐫𝐝  |  ![original-hard-dark](https://user-images.githubusercontent.com/58662350/213884080-8f3be305-8ff1-48d2-9bc8-c6db4ed9c143.png)  |  ![original-hard-light](https://user-images.githubusercontent.com/58662350/213884083-becbfe22-e063-4dcd-8ee0-14fc5b52c77b.png)  |
-| 𝐌𝐞𝐝𝐢𝐮𝐦 | ![original-medium-dark](https://user-images.githubusercontent.com/58662350/213884089-4cea3374-b918-4bd1-8ca5-ac87a9bb9d83.png) | ![original-medium-light](https://user-images.githubusercontent.com/58662350/213884092-b4336e83-8556-4f04-a0e5-8e18ab57800f.png) |
-|  𝐒𝐨𝐟𝐭  |  ![original-soft-dark](https://user-images.githubusercontent.com/58662350/213884099-88d47fa6-ea20-49ad-b706-072e928b3e0a.png)  |  ![original-soft-light](https://user-images.githubusercontent.com/58662350/213884102-ab77fd5a-455f-4195-a7bb-61182d2989fc.png)  |
+|  𝐇𝐚𝐫𝐝  |  ![original-hard-dark](https://user-images.githubusercontent.com/37491630/76383382-8e5b3980-6353-11ea-9398-08d31b1ed32d.png) ![original-hard-dark](https://user-images.githubusercontent.com/58662350/213884080-8f3be305-8ff1-48d2-9bc8-c6db4ed9c143.png)  |  ![original-hard-light](https://user-images.githubusercontent.com/37491630/76383389-931fed80-6353-11ea-905f-47b35c0cac39.png) ![original-hard-light](https://user-images.githubusercontent.com/58662350/213884083-becbfe22-e063-4dcd-8ee0-14fc5b52c77b.png)  |
+| 𝐌𝐞𝐝𝐢𝐮𝐦 | ![original-medium-dark](https://user-images.githubusercontent.com/37491630/76383385-9024fd00-6353-11ea-99c1-7bba4f796115.png) ![original-medium-dark](https://user-images.githubusercontent.com/58662350/213884089-4cea3374-b918-4bd1-8ca5-ac87a9bb9d83.png) | ![original-medium-light](https://user-images.githubusercontent.com/37491630/76383393-94511a80-6353-11ea-84ea-551b44f0d5bd.png) ![original-medium-light](https://user-images.githubusercontent.com/58662350/213884092-b4336e83-8556-4f04-a0e5-8e18ab57800f.png) |
+|  𝐒𝐨𝐟𝐭  |  ![original-soft-dark](https://user-images.githubusercontent.com/37491630/76383387-91562a00-6353-11ea-90a0-daac8653dfd0.png) ![original-soft-dark](https://user-images.githubusercontent.com/58662350/213884099-88d47fa6-ea20-49ad-b706-072e928b3e0a.png)  |  ![original-soft-light](https://user-images.githubusercontent.com/37491630/76383396-95824780-6353-11ea-9b36-302b88fef429.png) ![original-soft-light](https://user-images.githubusercontent.com/58662350/213884102-ab77fd5a-455f-4195-a7bb-61182d2989fc.png)  |
 
 </details>
 


### PR DESCRIPTION
This PR adds full palette previews with colors extracted from [the vim file](https://github.com/sainnhe/gruvbox-material/blob/master/autoload/gruvbox_material.vim), autogenerated using [my own script](https://github.com/Aonodensetsu/palette-preview-generator). This aims to fix #149. The preview files were uploaded to GitHub User Content to not take up disk space for users installing the themes into vim.

As I said, the colors were extracted from the files, so their names match highlight group names and a few are missing. I am available for any further help regarding this improvement.