### PR TITLE
feat: add option to fully highlight virtual texts

### DIFF
--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -10,7 +10,7 @@
 let s:configuration = gruvbox_material#get_configuration()
 let s:palette = gruvbox_material#get_palette(s:configuration.background, s:configuration.foreground, s:configuration.colors_override)
 let s:path = expand('<sfile>:p') " the path of this script
-let s:last_modified = 'Fri Apr 21 21:30:29 UTC 2023'
+let s:last_modified = 'Sat Apr 22 21:12:18 UTC 2023'
 let g:gruvbox_material_loaded_file_types = []
 
 if !(exists('g:colors_name') && g:colors_name ==# 'gruvbox-material' && s:configuration.better_performance)
@@ -456,11 +456,16 @@ if s:configuration.diagnostic_virtual_text ==# 'grey'
   highlight! link VirtualTextError Grey
   highlight! link VirtualTextInfo Grey
   highlight! link VirtualTextHint Grey
-else
+elseif s:configuration.diagnostic_virtual_text ==# 'colored'
   highlight! link VirtualTextWarning Yellow
   highlight! link VirtualTextError Red
   highlight! link VirtualTextInfo Blue
   highlight! link VirtualTextHint Green
+else
+  call gruvbox_material#highlight('VirtualTextWarning', s:palette.yellow, s:palette.bg_visual_yellow)
+  call gruvbox_material#highlight('VirtualTextError', s:palette.red, s:palette.bg_visual_red)
+  call gruvbox_material#highlight('VirtualTextInfo', s:palette.blue, s:palette.bg_visual_blue)
+  call gruvbox_material#highlight('VirtualTextHint', s:palette.green, s:palette.bg_visual_green)
 endif
 call gruvbox_material#highlight('ErrorFloat', s:palette.red, s:palette.bg3)
 call gruvbox_material#highlight('WarningFloat', s:palette.yellow, s:palette.bg3)

--- a/doc/gruvbox-material.txt
+++ b/doc/gruvbox-material.txt
@@ -421,17 +421,17 @@ Currently, the following plugins are supported:
                                     *g:gruvbox_material_diagnostic_virtual_text*
 g:gruvbox_material_diagnostic_virtual_text~
 
-Some plugins can use virtual text feature of neovim to display
-error/warning/info/hint information, you can use this option to adjust the
-colors of it.
+Some plugins can use the virtual text feature of Neovim to display
+error/warning/info/hint information. You can use this option to adjust the
+way these virtual texts are highlighted.
 
     Type:               |String|
-    Available values:   `'grey'`, `'colored'`
+    Available values:   `'grey'`, `'colored'`, `'highlighted'`
     Default value:      `'grey'`
 
 Currently, the following plugins are supported:
 
-- neovim's built-in language server client
+- Neovim's built-in language server client
 - https://github.com/neoclide/coc.nvim
 - https://github.com/prabirshrestha/vim-lsp
 - https://github.com/dense-analysis/ale


### PR DESCRIPTION
Closes #167

Allows the `g:gruvbox_material_diagnostic_virtual_text` option to accept the new value `highlighted`, besides `grey` (default) and `colored`.

With this option set, virtual texts have their background highlighted as well as their text.

See demo in https://github.com/sainnhe/gruvbox-material/issues/167#issuecomment-1518772915