### PR TITLE
fix(indent-blankline): update highlight groups for indent-blankline version 3

### DIFF
--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -10,7 +10,7 @@
 let s:configuration = gruvbox_material#get_configuration()
 let s:palette = gruvbox_material#get_palette(s:configuration.background, s:configuration.foreground, s:configuration.colors_override)
 let s:path = expand('<sfile>:p') " the path of this script
-let s:last_modified = 'Mon Aug  7 07:21:35 UTC 2023'
+let s:last_modified = 'Tue Oct  3 17:59:07 UTC 2023'
 let g:gruvbox_material_loaded_file_types = []
 
 if !(exists('g:colors_name') && g:colors_name ==# 'gruvbox-material' && s:configuration.better_performance)
@@ -1231,10 +1231,8 @@ highlight! link HopNextKey2 Green
 highlight! link HopUnmatched Grey
 " }}}
 " lukas-reineke/indent-blankline.nvim {{{
-call gruvbox_material#highlight('IndentBlanklineContextChar', s:palette.grey1, s:palette.none, 'nocombine')
-call gruvbox_material#highlight('IndentBlanklineChar', s:palette.bg5, s:palette.none, 'nocombine')
-highlight! link IndentBlanklineSpaceChar IndentBlanklineChar
-highlight! link IndentBlanklineSpaceCharBlankline IndentBlanklineChar
+call gruvbox_material#highlight('IblScope', s:palette.grey1, s:palette.none, 'nocombine')
+call gruvbox_material#highlight('IblIndent', s:palette.bg5, s:palette.none, 'nocombine')
 " }}}
 " p00f/nvim-ts-rainbow {{{
 highlight! link rainbowcol1 Red

--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -10,7 +10,7 @@
 let s:configuration = gruvbox_material#get_configuration()
 let s:palette = gruvbox_material#get_palette(s:configuration.background, s:configuration.foreground, s:configuration.colors_override)
 let s:path = expand('<sfile>:p') " the path of this script
-let s:last_modified = 'Tue Oct  3 17:59:07 UTC 2023'
+let s:last_modified = 'Tue Oct  3 20:27:18 UTC 2023'
 let g:gruvbox_material_loaded_file_types = []
 
 if !(exists('g:colors_name') && g:colors_name ==# 'gruvbox-material' && s:configuration.better_performance)
@@ -1233,6 +1233,10 @@ highlight! link HopUnmatched Grey
 " lukas-reineke/indent-blankline.nvim {{{
 call gruvbox_material#highlight('IblScope', s:palette.grey1, s:palette.none, 'nocombine')
 call gruvbox_material#highlight('IblIndent', s:palette.bg5, s:palette.none, 'nocombine')
+highlight! link IndentBlanklineContextChar IblScope
+highlight! link IndentBlanklineChar IblIndent
+highlight! link IndentBlanklineSpaceChar IndentBlanklineChar
+highlight! link IndentBlanklineSpaceCharBlankline IndentBlanklineChar
 " }}}
 " p00f/nvim-ts-rainbow {{{
 highlight! link rainbowcol1 Red


### PR DESCRIPTION
[Indent-blankline version 3](https://github.com/lukas-reineke/indent-blankline.nvim/wiki/Migrate-to-version-3#highlights) changes the highlight groups which means the indentation guides no longer highlight properly.

The following highlight groups have been renamed to match the new names:
- IndentBlanklineContextChar -> Iblscope
- IndentBlanklineChar -> IblIndent

The highlight groups IndentBlanklineSpaceChar and IndentBlanklineSpaceCharBlankline have been removed from Indent-blankline version 3 so the highlight links are no longer needed.
