### PR TITLE
feat(configuration): add g:gruvbox_material_inlay_hints_background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Optimize `github/copilot.vim`.
+- Add `g:gruvbox_material_inlay_hints_background`.
 
 ## [1.2.5] - 2023-01-14
 

--- a/autoload/gruvbox_material.vim
+++ b/autoload/gruvbox_material.vim
@@ -24,6 +24,7 @@ function! gruvbox_material#get_configuration() "{{{
         \ 'show_eob': get(g:, 'gruvbox_material_show_eob', 1),
         \ 'float_style': get(g:, 'gruvbox_material_float_style', 'bright'),
         \ 'current_word': get(g:, 'gruvbox_material_current_word', get(g:, 'gruvbox_material_transparent_background', 0) == 0 ? 'grey background' : 'bold'),
+        \ 'inlay_hints_background': get(g:, 'gruvbox_material_inlay_hints_background', 'none'),
         \ 'statusline_style': get(g:, 'gruvbox_material_statusline_style', 'default'),
         \ 'lightline_disable_bold': get(g:, 'gruvbox_material_lightline_disable_bold', 0),
         \ 'diagnostic_text_highlight': get(g:, 'gruvbox_material_diagnostic_text_highlight', 0),

--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -10,7 +10,7 @@
 let s:configuration = gruvbox_material#get_configuration()
 let s:palette = gruvbox_material#get_palette(s:configuration.background, s:configuration.foreground, s:configuration.colors_override)
 let s:path = expand('<sfile>:p') " the path of this script
-let s:last_modified = 'Wed May 15 08:28:29 PM UTC 2024'
+let s:last_modified = 'Fri May 17 09:33:15 UTC 2024'
 let g:gruvbox_material_loaded_file_types = []
 
 if !(exists('g:colors_name') && g:colors_name ==# 'gruvbox-material' && s:configuration.better_performance)
@@ -299,6 +299,7 @@ if has('nvim')
   highlight! link LspReferenceText CurrentWord
   highlight! link LspReferenceRead CurrentWord
   highlight! link LspReferenceWrite CurrentWord
+  highlight! link LspInlayHint InlayHints
   highlight! link LspCodeLens VirtualTextInfo
   highlight! link LspCodeLensSeparator VirtualTextHint
   highlight! link LspSignatureActiveParameter Search
@@ -480,6 +481,15 @@ elseif s:configuration.current_word ==# 'grey background'
   call gruvbox_material#highlight('CurrentWord', s:palette.none, s:palette.bg_current_word)
 else
   call gruvbox_material#highlight('CurrentWord', s:palette.none, s:palette.none, s:configuration.current_word)
+endif
+if s:configuration.inlay_hints_background ==# 'none'
+  highlight! link InlayHints LineNr
+else
+  if &background ==# 'dark'
+    call gruvbox_material#highlight('InlayHints', s:palette.grey0, s:palette.bg_dim)
+  else
+    call gruvbox_material#highlight('InlayHints', s:palette.grey1, s:palette.bg_dim)
+  endif
 endif
 " Define a color for each LSP item kind to create highlights for nvim-cmp, aerial.nvim, nvim-navic and coc.nvim
 let g:gruvbox_material_lsp_kind_color = [
@@ -805,7 +815,7 @@ highlight! link CocPumMenu Pmenu
 highlight! link CocMenuSel PmenuSel
 highlight! link CocDisabled Grey
 highlight! link CocSnippetVisual DiffAdd
-highlight! link CocInlayHint LineNr
+highlight! link CocInlayHint InlayHints
 highlight! link CocNotificationProgress Green
 highlight! link CocNotificationButton PmenuSel
 highlight! link CocSemClass TSType
@@ -866,8 +876,8 @@ highlight! link LspWarningHighlight WarningText
 highlight! link LspInformationHighlight InfoText
 highlight! link LspHintHighlight HintText
 highlight! link lspReference CurrentWord
-highlight! link lspInlayHintsType LineNr
-highlight! link lspInlayHintsParameter LineNr
+highlight! link lspInlayHintsType InlayHints
+highlight! link lspInlayHintsParameter InlayHints
 highlight! link LspSemanticType TSType
 highlight! link LspSemanticClass TSType
 highlight! link LspSemanticEnum TSType
@@ -896,7 +906,7 @@ highlight! link YcmErrorLine ErrorLine
 highlight! link YcmWarningLine WarningLine
 highlight! link YcmErrorSection ErrorText
 highlight! link YcmWarningSection WarningText
-highlight! link YcmInlayHint LineNr
+highlight! link YcmInlayHint InlayHints
 highlight! link YcmErrorText VirtualTextError
 highlight! link YcmWarningText VirtualTextWarning
 if !has('nvim') && has('textprop') && !exists('g:YCM_HIGHLIGHT_GROUP')

--- a/doc/gruvbox-material.txt
+++ b/doc/gruvbox-material.txt
@@ -508,6 +508,25 @@ Currently, the following plugins are supported:
 - https://github.com/prabirshrestha/vim-lsp
 
 ------------------------------------------------------------------------------
+                                     *g:gruvbox_material_inlay_hints_background*
+g:gruvbox_material_inlay_hints_background~
+
+Inlay hints are special markers that are displayed inline with the code to
+provide you with additional information. You can use this option to customize
+the background color of inlay hints.
+
+    Type:               |String|
+    Available values:   `'none'`, `'dimmed'`
+    Default value:      `'none'`
+
+Currently, the following LSP clients are supported:
+
+- neovim's built-in language server client
+- https://github.com/neoclide/coc.nvim
+- https://github.com/prabirshrestha/vim-lsp
+- https://github.com/ycm-core/YouCompleteMe
+
+------------------------------------------------------------------------------
                                     *g:gruvbox_material_disable_terminal_colors*
 g:gruvbox_material_disable_terminal_colors~
 


### PR DESCRIPTION
Fix #190 

This PR adds a config option named `g:gruvbox_material_inlay_hints_background` which has two possible values:

1. `none`: default value, no background
2. `dimmed`: dimmed background

Preview of dimmed background:

<img width="1440" alt="截屏2024-05-17 13 58 05" src="https://github.com/sainnhe/gruvbox-material/assets/37491630/2bf7068b-036e-41e1-9efa-bba36019b177">

<img width="1440" alt="截屏2024-05-17 13 58 28" src="https://github.com/sainnhe/gruvbox-material/assets/37491630/584f1db5-97ea-4678-8a62-83793bfc459d">

I'm considering using `dimmed` as default value since it looks easier for reading.

@antoineco Could you try this branch?