### PR TITLE
fix(vim): invisible git DiffText and coc Search highlight when cursorline is set

### DIFF
--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -108,7 +108,11 @@ endif
 call gruvbox_material#highlight('DiffAdd', s:palette.none, s:palette.bg_diff_green)
 call gruvbox_material#highlight('DiffChange', s:palette.none, s:palette.bg_diff_blue)
 call gruvbox_material#highlight('DiffDelete', s:palette.none, s:palette.bg_diff_red)
-call gruvbox_material#highlight('DiffText', s:palette.bg0, s:palette.blue)
+if has('nvim')
+  call gruvbox_material#highlight('DiffText', s:palette.bg0, s:palette.blue)
+else
+  call gruvbox_material#highlight('DiffText', s:palette.blue, s:palette.bg0, 'reverse')
+endif
 call gruvbox_material#highlight('Directory', s:palette.green, s:palette.none)
 call gruvbox_material#highlight('ErrorMsg', s:palette.red, s:palette.none, 'bold,underline')
 if s:configuration.ui_contrast ==# 'low'

--- a/colors/gruvbox-material.vim
+++ b/colors/gruvbox-material.vim
@@ -72,8 +72,13 @@ else
     endif
   endif
 endif
-call gruvbox_material#highlight('IncSearch', s:palette.bg0, s:palette.bg_red)
-call gruvbox_material#highlight('Search', s:palette.bg0, s:palette.bg_green)
+if has('nvim')
+  call gruvbox_material#highlight('IncSearch', s:palette.bg0, s:palette.bg_red)
+  call gruvbox_material#highlight('Search', s:palette.bg0, s:palette.bg_green)
+else
+  call gruvbox_material#highlight('IncSearch', s:palette.bg_red, s:palette.bg0, 'reverse')
+  call gruvbox_material#highlight('Search', s:palette.bg_green, s:palette.bg0, 'reverse')
+endif
 highlight! link CurSearch IncSearch
 call gruvbox_material#highlight('ColorColumn', s:palette.none, s:palette.bg2)
 if s:configuration.ui_contrast ==# 'low'


### PR DESCRIPTION
Hi there,

I was facing the same issue like 80331fb but when git diffing with [pope/vim-fugitive](https://github.com/tpope/vim-fugitive) and using [neoclide/coc.nvim](https://github.com/neoclide/coc.nvim) LSP find references functionality (solargraph in my case).

Thanks to the detailed investigation and solution on the previous fix, I could replicate and fix both these cases. Though I must say that this is the first time I'm doing Vim changes regarding the theeming, so take it with a grain of salt, since I'm not entirely sure how the fix works. This is mainly reverse-engineering :D. 

### Git diff

#### Before

* When cursor is NOT on the diff line
![image_1727001510768_0](https://github.com/user-attachments/assets/d1624d9a-a395-433e-93ae-19bf254a7127)

* When cursor is on the diff line
![image_1727001523557_0](https://github.com/user-attachments/assets/a1be7898-84b6-4e46-bc5f-d71cca766b38)

#### After


* When cursor is NOT on the diff line
![image_1727001506104_0](https://github.com/user-attachments/assets/c2f70de2-998c-4eee-b034-5968ef6e7d0a)

* When cursor is on the diff line
![image_1727001806803_0](https://github.com/user-attachments/assets/6ef9443b-8015-4e2f-a3d3-0495d6b1081b)

### Coc LSP find-references

#### Before
![image_1727001658036_0](https://github.com/user-attachments/assets/98ee42a2-996b-4daa-9bd9-a2c8e6f6c7c5)


#### After
![image_1727001252357_0](https://github.com/user-attachments/assets/7976e0b2-3c73-4363-a390-ddfe78613639)

Cheers!