### PR TITLE
Escape paths containing space (because windows)

### DIFF
--- a/autoload/gruvbox_material.vim
+++ b/autoload/gruvbox_material.vim
@@ -319,7 +319,7 @@ function! gruvbox_material#syn_gen(path, last_modified, msg) "{{{
     call gruvbox_material#ftplugin_detect(a:path)
   else
     echohl WarningMsg | echom '[gruvbox-material] Generated ' . rootpath . syntax_relative_path | echohl None
-    execute 'set runtimepath+=' . fnamemodify(rootpath, ':p') . 'after'
+    execute 'set runtimepath+=' . fnameescape(fnamemodify(rootpath, ':p')) . 'after'
   endif
 endfunction "}}}
 function! gruvbox_material#syn_write(rootpath, syn, content) "{{{


### PR DESCRIPTION

The following content was showing up in `:messages` on startup after installing gruvbox-material and setting it as the colorscheme.

```plaintext
[gruvbox-material] Generated C:\Users\Dakota Lorance\AppData\Local\nvim-data\lazy\gruvbox-material\after\syntax
Failed to run `config` for gruvbox-material
vim/_editor.lua:431: C:\Users\Dakota Lorance\.config\nvim\init.lua..
nvim_exec2()
called at C:\Users\Dakota Lorance\.config\nvim\init.lua:0..
C:\Users\Dakota Lorance\AppData\Local\nvim-data\lazy\gruvbox-material\colors\gruvbox-material.vim[1622]..
function gruvbox_material#syn_gen, line 20: Vim(set):E518: Unknown option: Lorance\AppData\Local\nvim-data\lazy\gruvbox-material\after 
```

The problem was caused by the default name of my windows user directory containing a space.

e.g.: `C:\Users\First Last\`