### PR TITLE
Fix lightline `tab_sel_bg` color merging with `tab_r_bg`

### DIFF
--- a/autoload/lightline/colorscheme/gruvbox_material.vim
+++ b/autoload/lightline/colorscheme/gruvbox_material.vim
@@ -21,7 +21,7 @@ if s:configuration.statusline_style ==# 'original' "{{{
   let s:tab_r_fg = s:palette.bg0
   let s:tab_r_bg = s:palette.grey2
   let s:tab_sel_fg = s:palette.bg0
-  let s:tab_sel_bg = s:palette.grey2
+  let s:tab_sel_bg = s:palette.grey1
   let s:tab_middle_fg = s:palette.grey1
   let s:tab_middle_bg = s:palette.bg0
 
@@ -112,7 +112,7 @@ elseif s:configuration.statusline_style ==# 'mix' "{{{
   let s:tab_r_fg = s:palette.bg0
   let s:tab_r_bg = s:palette.grey2
   let s:tab_sel_fg = s:palette.bg0
-  let s:tab_sel_bg = s:palette.grey2
+  let s:tab_sel_bg = s:palette.grey1
   let s:tab_middle_fg = s:palette.grey2
   let s:tab_middle_bg = s:palette.bg_statusline2
 
@@ -203,7 +203,7 @@ else "{{{
   let s:tab_r_fg = s:palette.bg0
   let s:tab_r_bg = s:palette.grey2
   let s:tab_sel_fg = s:palette.bg0
-  let s:tab_sel_bg = s:palette.grey2
+  let s:tab_sel_bg = s:palette.grey1
   let s:tab_middle_fg = s:palette.fg1
   let s:tab_middle_bg = s:palette.bg_statusline1
 


### PR DESCRIPTION
I am using lightline#bufferline  to browser buffers, gitrootdir, relative path in lightline

tab_sel_bg  is the same as tab_r_bg so looks strange
![image](https://github.com/user-attachments/assets/6612227f-5532-401b-bc65-ba61e8c316d3)

affer the modification

![image](https://github.com/user-attachments/assets/0a0e97d3-9cb7-42b6-ad77-1b0641f86714)

sonokai and edge did not have this problem , but  everest still has this problem