### PR TITLE
change normal_l1_bg to be different from tab_sel_bg

### DIFF
--- a/autoload/lightline/colorscheme/gruvbox_material.vim
+++ b/autoload/lightline/colorscheme/gruvbox_material.vim
@@ -31,7 +31,7 @@ if s:configuration.statusline_style ==# 'original' "{{{
   let s:errorbg = s:palette.red
 
   let s:normal_l1_fg = s:palette.bg0
-  let s:normal_l1_bg = s:palette.grey2
+  let s:normal_l1_bg = s:palette.grey1
   let s:normal_l2_fg = s:palette.grey2
   let s:normal_l2_bg = s:palette.bg_statusline3
   let s:normal_r1_fg = s:palette.bg0
@@ -122,7 +122,7 @@ elseif s:configuration.statusline_style ==# 'mix' "{{{
   let s:errorbg = s:palette.bg_red
 
   let s:normal_l1_fg = s:palette.bg0
-  let s:normal_l1_bg = s:palette.grey2
+  let s:normal_l1_bg = s:palette.grey1
   let s:normal_l2_fg = s:palette.grey2
   let s:normal_l2_bg = s:palette.bg_statusline3
   let s:normal_r1_fg = s:palette.bg0
@@ -213,7 +213,7 @@ else "{{{
   let s:errorbg = s:palette.bg_red
 
   let s:normal_l1_fg = s:palette.bg0
-  let s:normal_l1_bg = s:palette.grey2
+  let s:normal_l1_bg = s:palette.grey1
   let s:normal_l2_fg = s:palette.fg1
   let s:normal_l2_bg = s:palette.bg_statusline3
   let s:normal_r1_fg = s:palette.bg0


### PR DESCRIPTION
according to https://github.com/sainnhe/gruvbox-material/pull/218#issuecomment-2541667002
actually the bg color changed should be `normal_l1_bg`,

This is the lightline after the commit
![image](https://github.com/user-attachments/assets/763d9c98-4d70-4c1f-b8f8-d9be460c14b2)
